### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/lib/cmd_wrapper.py
+++ b/lib/cmd_wrapper.py
@@ -79,13 +79,13 @@ def get_cmd_output(hostname, topic, request_options):
         if topic != ':firstpage':
             try:
                 answer = calculator.calculate(topic.upper(), currency)
-            except ValueError, e:
+            except ValueError as e:
                 return "ERROR: %s\n" % e
 
             if answer is None:
                 try:
                     answer = draw.view(topic, use_currency=use_currency)
-                except RuntimeError, e:
+                except RuntimeError as e:
                     return "ERROR: %s\n" % e
 
             if answer is not None:

--- a/lib/draw.py
+++ b/lib/draw.py
@@ -46,6 +46,7 @@
 34 [X] add a warning if interval is truncated
 35 [ ] add a warning if one of the currencies is overridden
 """
+from __future__ import print_function
 
 import sys
 import datetime
@@ -345,7 +346,7 @@ class Diagram(object):  # pylint: disable=too-many-instance-attributes
         """
         Show diagram on the standard output.
         """
-        print self.make_view()
+        print(self.make_view())
 
 def _split_query(query):
 
@@ -406,7 +407,7 @@ def view(query, use_currency=None):
             or currencies_names.currency_name(use_currency) != ''):
         coin2 = use_currency
 
-    print coin2
+    print(coin2)
     ticks = 80
     if coin2:
         data = aggregate.get_aggregated_pair(coin, coin2, time_begin, time_end, ticks)
@@ -445,7 +446,7 @@ def main():
     try:
         sys.stdout.write(view(query))
     except RuntimeError as e_msg:
-        print "ERROR: %s" % e_msg
+        print("ERROR: %s" % e_msg)
         sys.exit(1)
 
 

--- a/lib/globals.py
+++ b/lib/globals.py
@@ -1,6 +1,7 @@
 """
 Global variables and most important functions.
 """
+from __future__ import print_function
 
 import logging
 import os
@@ -35,7 +36,7 @@ def error(text):
     Fatal error. Log ``text`` and produce a RuntimeException
     """
     if not text.startswith('Too many queries'):
-        print text
+        print(text)
     logging.error("ERROR %s", text)
     raise RuntimeError(text)
 
@@ -44,5 +45,5 @@ def log(text):
     Log ``text`` to the log and on the standard out and continue
     """
     if not text.startswith('Too many queries'):
-        print text
+        print(text)
         logging.info(text)

--- a/lib/panela/panela_colors.py
+++ b/lib/panela/panela_colors.py
@@ -373,8 +373,8 @@ class Panela:
             char_iter = itertools.repeat(char)
 
         for x, y in get_line((x1,y1), (x2, y2)):
-            char = char_iter.next()
-            color = color_iter.next()
+            char = next(char_iter)
+            color = next(color_iter)
             background = next(background_iter)
 
             self.put_point(x, y, char=char, color=color, background=background)

--- a/lib/spark.py
+++ b/lib/spark.py
@@ -1,5 +1,6 @@
 #vim:encoding=utf-8
 
+from __future__ import print_function
 import math
 from termcolor import colored
 
@@ -37,6 +38,6 @@ def spark(vals):
 
 if __name__ == '__main__':
     data = [1,-1,2,-2,3,-3,4,-4,5,-5]
-    print spark_numbers(data)
-    print spark(data)
+    print(spark_numbers(data))
+    print(spark(data))
 

--- a/lib/view.py
+++ b/lib/view.py
@@ -46,7 +46,7 @@ def show(config):
                     (market_cap_direction, vol_24h_direction, btc_dominance_direction),
                     marktcap_spark)
 
-    except ValueError, e:
+    except ValueError as e:
         output = "ERROR: %s" % s
 
     return output


### PR DESCRIPTION
* Old style exceptions --> new style for Python 3
    * Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.
* Use __print()__ function in both Python 2 and Python 3
    * Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.