### PR TITLE
Fixed requirements and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ server {
     error_log  /var/log/nginx/rate.sx-error.log;
 
     location / {
-        proxy_pass         http://127.0.0.1:8003;
+        proxy_pass         http://127.0.0.1:8004;
 
         proxy_set_header   Host             $host;
         proxy_set_header   X-Real-IP        $remote_addr;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,14 @@
-gevent
+diagram
+colorclass~=1.1.2
+pymongo
+gevent~=1.2.2
 flask
 pygments
 requests
 dateutils
 redis
 colored
-terminaltables
+terminaltables~=1.2.1
 colorama
 termcolor
 PyYAML


### PR DESCRIPTION
Some packages needed to be downgraded to get rate.sx to run. Also, I fixed the port number in README.md, from 8003 to 8004.