### PR TITLE
crypTocurrency typo corrected

### DIFF
--- a/share/help.txt
+++ b/share/help.txt
@@ -56,7 +56,7 @@ DISCLAIMER:
     we cannot guarantee absolute accuracy of the displayed exchange rates.
     You should always confirm current rates before making any transactions
     that could be affected by changes in the exchange rates.
-    Crypocurrency rates based on the data provided by exchanges APIs.
+    Cryptocurrency rates based on the data provided by exchanges APIs.
     All rates are for information purposes only and are subject to change without prior notice.
     Since rates for actual transactions may vary,
     we are not offering to enter into any transaction at any rate displayed.


### PR DESCRIPTION
Hi there, just correcting a small typo I found in the command's help message.