### PR TITLE
add Chia (XCH)

### DIFF
--- a/lib/coins_names.py
+++ b/lib/coins_names.py
@@ -1033,6 +1033,9 @@ COINS_NAMES = (
     ("MATIC",   "Polygon"),
     ("ALGO",    "Algorand"),
     ("BETH",    "Beacon ETH"),
+
+# 2023-09-15 additions
+    ("XCH",     "Chia"),
 )
     # ("BTG", "Bitgem"),
 


### PR DESCRIPTION
https://chia.net

Mainnet launched March 2021

- CMC: https://coinmarketcap.com/currencies/chia-network/
- docs: https://docs.chia.net
- peer-info: https://dashboard.chia.net/d/em15uQ47k/peer-info?orgId=1
